### PR TITLE
Simply adds mysql2 adapter compatibility to the adapter extension and import module 

### DIFF
--- a/ar-extensions/ar-extensions.gemspec
+++ b/ar-extensions/ar-extensions.gemspec
@@ -1,5 +1,3 @@
-require 'rake'
-
 Gem::Specification.new do |s|
   s.name = %q{ar-extensions}
   s.version = "0.9.5"

--- a/ar-extensions/ar-extensions.gemspec
+++ b/ar-extensions/ar-extensions.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files = FileList[ 'init.rb', 'db/**/*', 'Rakefile', 'ChangeLog', 'README', 'config/**/*', 'lib/**/*.rb', 'test/**/*' ]
   s.rdoc_options = ["--main", "README"]
   s.extra_rdoc_files = ["README"]
-  s.add_dependency("activerecord", "~> 2.1")
-  s.add_dependency("rake", ">= 0.9.2")
+  s.add_dependency(%q<activerecord>, ["~> 2.1"])
+  s.add_dependency(%q<rake>, [">= 0.9.2"])
 end

--- a/ar-extensions/ar-extensions.gemspec
+++ b/ar-extensions/ar-extensions.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.files = FileList[ 'init.rb', 'db/**/*', 'Rakefile', 'ChangeLog', 'README', 'config/**/*', 'lib/**/*.rb', 'test/**/*' ]
   s.rdoc_options = ["--main", "README"]
   s.extra_rdoc_files = ["README"]
-  s.add_dependency(%q<activerecord>, ["~> 2.1"])
+  s.add_dependency("activerecord", "~> 2.1")
+  s.add_dependency("rake", ">= 0.9.2")
 end

--- a/ar-extensions/ar-extensions.gemspec
+++ b/ar-extensions/ar-extensions.gemspec
@@ -1,3 +1,5 @@
+require "rake"
+
 Gem::Specification.new do |s|
   s.name = %q{ar-extensions}
   s.version = "0.9.5"
@@ -10,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.has_rdoc = true
   s.authors = ["Zach Dennis", "Mark Van Holstyn", "Blythe Dunham"]
-  s.files = FileList[ 'init.rb', 'db/**/*', 'Rakefile', 'ChangeLog', 'README', 'config/**/*', 'lib/**/*.rb', 'test/**/*' ]
+  s.files = `git ls-files`.split($\)
   s.rdoc_options = ["--main", "README"]
   s.extra_rdoc_files = ["README"]
   s.add_dependency(%q<activerecord>, ["~> 2.1"])

--- a/ar-extensions/lib/ar-extensions.rb
+++ b/ar-extensions/lib/ar-extensions.rb
@@ -3,3 +3,11 @@ require 'active_record' # ActiveRecord loads the Benchmark library automatically
 require 'active_record/version'
 
 require File.expand_path(File.join( File.dirname( __FILE__ ), '..', 'init.rb' ))
+
+MYSQL_ADAPTER_CLASS = if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
+  ActiveRecord::ConnectionAdapters::MysqlAdapter
+elsif defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  ActiveRecord::ConnectionAdapters::Mysql2Adapter
+else
+  raise "ar-extensions: Missing or unknown ActiveRecord::ConnectionAdapter"
+end

--- a/ar-extensions/lib/ar-extensions.rb
+++ b/ar-extensions/lib/ar-extensions.rb
@@ -4,6 +4,7 @@ require 'active_record/version'
 
 require File.expand_path(File.join( File.dirname( __FILE__ ), '..', 'init.rb' ))
 
+# Set MYSQL_ADAPTER_CLASS to the used and defined MysqlAdapter class dynamically and use this later on to do the mixins 
 MYSQL_ADAPTER_CLASS = if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
   ActiveRecord::ConnectionAdapters::MysqlAdapter
 elsif defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter

--- a/ar-extensions/lib/ar-extensions/adapters/mysql.rb
+++ b/ar-extensions/lib/ar-extensions/adapters/mysql.rb
@@ -3,6 +3,7 @@ MYSQL_ADAPTER_CLASS.class_eval do
   # in a single packet
   def max_allowed_packet # :nodoc:
     result = execute( "SHOW VARIABLES like 'max_allowed_packet';" )
+    # original Mysql gem responds to #fetch_row while Mysql2 responds to #first
     (result.respond_to?(:fetch_row) ? result.fetch_row[1].to_i : result.first[1]).to_i
   end
 

--- a/ar-extensions/lib/ar-extensions/adapters/mysql.rb
+++ b/ar-extensions/lib/ar-extensions/adapters/mysql.rb
@@ -3,7 +3,7 @@ MYSQL_ADAPTER_CLASS.class_eval do
   # in a single packet
   def max_allowed_packet # :nodoc:
     result = execute( "SHOW VARIABLES like 'max_allowed_packet';" )
-    result.respond_to?(:fetch_row) ? result.fetch_row[1].to_i : result.first[1]
+    (result.respond_to?(:fetch_row) ? result.fetch_row[1].to_i : result.first[1]).to_i
   end
 
   def rollup_sql; " WITH ROLLUP "; end

--- a/ar-extensions/lib/ar-extensions/adapters/mysql.rb
+++ b/ar-extensions/lib/ar-extensions/adapters/mysql.rb
@@ -1,9 +1,9 @@
-ActiveRecord::ConnectionAdapters::MysqlAdapter.class_eval do
+MYSQL_ADAPTER_CLASS.class_eval do
   # Returns the maximum number of bytes that the server will allow
   # in a single packet
   def max_allowed_packet # :nodoc:
     result = execute( "SHOW VARIABLES like 'max_allowed_packet';" )
-    result.fetch_row[1].to_i
+    result.respond_to?(:fetch_row) ? result.fetch_row[1].to_i : result.first[1]
   end
 
   def rollup_sql; " WITH ROLLUP "; end

--- a/ar-extensions/lib/ar-extensions/delete/mysql.rb
+++ b/ar-extensions/lib/ar-extensions/delete/mysql.rb
@@ -1,3 +1,3 @@
-ActiveRecord::ConnectionAdapters::MysqlAdapter.class_eval do
+MYSQL_ADAPTER_CLASS.class_eval do
   include ActiveRecord::Extensions::Delete::DeleteSupport
 end

--- a/ar-extensions/lib/ar-extensions/import/mysql.rb
+++ b/ar-extensions/lib/ar-extensions/import/mysql.rb
@@ -45,6 +45,6 @@ module ActiveRecord::Extensions::ConnectionAdapters::MysqlAdapter # :nodoc:
 
 end
 
-ActiveRecord::ConnectionAdapters::MysqlAdapter.class_eval do
+MYSQL_ADAPTER_CLASS.class_eval do
   include ActiveRecord::Extensions::ConnectionAdapters::MysqlAdapter
 end


### PR DESCRIPTION
This comes in useful when using mysql2 Gem with Rails 2.x. (You can't use activerecord-import gem in this case). The changes are very straightforward and could easily be also taken over to the other ar-extension modules. Just use the dynamically set MYSQL_ADAPTER_CLASS for the mixins instead of ActiveRecord::ConnectionAdapters::MysqlAdapter directly.
